### PR TITLE
Resolves #1

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -9,7 +9,7 @@ namespace RazorPagesTestSample.Data
 
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(300, ErrorMessage = "There's a 300 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion


### PR DESCRIPTION
This pull request includes a small update to the `Message` class in the `RazorPagesTestSample` project. The change increases the character limit for messages from 200 to 300 characters.

* [`src/Application/src/RazorPagesTestSample/Data/Message.cs`](diffhunk://#diff-3ce635672d23bd9cdaa8656d8d117fc07bbea38b87de905339a765df73f3c450L12-R12): Increased the `StringLength` attribute limit from 200 to 300 characters for the `Text` property.